### PR TITLE
Only perform one trial when determining if a packet is dropped

### DIFF
--- a/src/stack/phy/ChannelModel/LteChannelModel.h
+++ b/src/stack/phy/ChannelModel/LteChannelModel.h
@@ -70,8 +70,9 @@ class LteChannelModel
      * @param lteinfo pointer to the user control info
      * @param rsrpVector the received signal for each RB, if it has already been computed
      * @param mcs the modulation and coding scheme used in sending the message.
+     * @returns a tuple specifying whether it was successfully received based on SNR and SINR
      */
-    virtual bool error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs, bool interference)=0;
+    virtual std::tuple<bool, bool> error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs)=0;
     /*
      * Compute Received useful signal for D2D transmissions
      */

--- a/src/stack/phy/ChannelModel/LteDummyChannelModel.cc
+++ b/src/stack/phy/ChannelModel/LteDummyChannelModel.cc
@@ -147,7 +147,7 @@ bool LteDummyChannelModel::error_D2D(LteAirFrame *frame, UserControlInfo* lteInf
     return true;
 }
 
-bool LteDummyChannelModel::error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo,std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs, bool interference=true)
+std::tuple<bool, bool> LteDummyChannelModel::error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo,std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs)
 {
     // Number of RTX
     unsigned char nTx = lteInfo->getTxNumber();
@@ -166,12 +166,12 @@ bool LteDummyChannelModel::error_Mode4(LteAirFrame *frame, UserControlInfo* lteI
         EV << "This is NOT your lucky day (" << er << " < " << totalPer
            << ") -> do not receive." << endl;
         // Signal too weak, we can't receive it
-        return false;
+        return std::make_tuple(false, false);
     }
     // Signal is strong enough, receive this Signal
     EV << "This is your lucky day (" << er << " > " << totalPer
        << ") -> Receive AirFrame." << endl;
-    return true;
+    return std::make_tuple(true, true);
 }
 
 double LteDummyChannelModel::getTxRxDistance(UserControlInfo* lteInfo)

--- a/src/stack/phy/ChannelModel/LteDummyChannelModel.h
+++ b/src/stack/phy/ChannelModel/LteDummyChannelModel.h
@@ -65,8 +65,9 @@ class LteDummyChannelModel : public LteChannelModel
      * @param lteinfo pointer to the user control info
      * @param rsrpVector the received signal for each RB, if it has already been computed
      * @param mcs the modulation and coding scheme used in sending the message.
+     * @returns a tuple specifying whether it was successfully received based on SNR and SINR
      */
-    virtual bool error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs, bool interference);
+    virtual std::tuple<bool, bool> error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs);
     /*
      * Compute Received useful signal for D2D transmissions
      */

--- a/src/stack/phy/ChannelModel/LteRealisticChannelModel.cc
+++ b/src/stack/phy/ChannelModel/LteRealisticChannelModel.cc
@@ -2203,7 +2203,7 @@ std::tuple<bool, bool> LteRealisticChannelModel::error_Mode4(LteAirFrame *frame,
         resultSnr = false;
     }
 
-    if (er <= blerSnr) {
+    if (er <= blerSinr) {
         // Interference too strong, we can't decode this packet
         resultSinr = false;
     }

--- a/src/stack/phy/ChannelModel/LteRealisticChannelModel.cc
+++ b/src/stack/phy/ChannelModel/LteRealisticChannelModel.cc
@@ -2061,7 +2061,7 @@ bool LteRealisticChannelModel::error_D2D(LteAirFrame *frame, UserControlInfo* lt
     return true;
 }
 
-bool LteRealisticChannelModel::error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs, bool interference)
+std::tuple<bool, bool> LteRealisticChannelModel::error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs)
 {
     EV << "LteRealisticChannelModel::error_Mode4" << endl;
 
@@ -2107,33 +2107,29 @@ bool LteRealisticChannelModel::error_Mode4(LteAirFrame *frame, UserControlInfo* 
     {
         //compare lambda min (smaller eingenvalues of channel matrix) with the threshold used to compute the rank
         if (binder_->phyPisaData.getLambda(id, 1) < lambdaMinTh_)
-            return false;
+            return std::make_tuple(false, false);
     }
 
-    // SINR vector(one SINR value for each band)
+    // SNR vector(one SNR value for each band)
     std::vector<double> snrV;
-    if (interference){
-        // We are calculating error based on SINR not SNR
-        snrV = sinrVector;
-    } else {
-        // We are calculating based on SNR only not SINR
-        if (lteInfo->getDirection() == D2D || lteInfo->getDirection() == D2D_MULTI) {
-            MacNodeId peerUeMacNodeId = lteInfo->getDestId();
-            Coord peerCoord = myCoord_;
-            // TODO get an appropriate way to get EnbId
-            MacNodeId enbId = 1;
+    if (lteInfo->getDirection() == D2D || lteInfo->getDirection() == D2D_MULTI) {
+        MacNodeId peerUeMacNodeId = lteInfo->getDestId();
+        Coord peerCoord = myCoord_;
+        // TODO get an appropriate way to get EnbId
+        MacNodeId enbId = 1;
 
-            if (lteInfo->getDirection() == D2D) {
-                snrV = getSINR_D2D(frame, lteInfo, peerUeMacNodeId, peerCoord, enbId);
-            } else  // D2D_MULTI
-            {
-                snrV = getSINR_D2D(frame, lteInfo, peerUeMacNodeId, peerCoord, enbId, rsrpVector, interference);
-            }
+        if (lteInfo->getDirection() == D2D) {
+            snrV = getSINR_D2D(frame, lteInfo, peerUeMacNodeId, peerCoord, enbId);
+        } else  // D2D_MULTI
+        {
+            snrV = getSINR_D2D(frame, lteInfo, peerUeMacNodeId, peerCoord, enbId, rsrpVector, false);
         }
     }
 
-    double bler = 0;
+    double blerSnr = 0;
+    double blerSinr = 0;
     double averageSnr = 0;
+    double averageSinr = 0;
     double countUsedRbs = 0;
 
     RbMap rbmap = lteInfo->getGrantedBlocks();
@@ -2156,38 +2152,63 @@ bool LteRealisticChannelModel::error_Mode4(LteAirFrame *frame, UserControlInfo* 
 
             //Get the Bler
             averageSnr += dBToLinear(snrV[jt->first]);
+            averageSinr += dBToLinear(sinrVector[jt->first]);
             countUsedRbs += 1;
         }
     }
 
     averageSnr = linearToDb(averageSnr/countUsedRbs);
+    averageSinr = linearToDb(averageSinr/countUsedRbs);
 
     if (averageSnr > binder_->phyPisaData.maxSnr())
-        bler = 0;
+        blerSnr = 0;
     else
     if (lteInfo->getFrameType() == SCIPKT)
     {
         // TODO: Make this slightly tidier.
-        bler = binder_->phyPisaData.GetPscchBler(binder_->phyPisaData.AWGN, binder_->phyPisaData.SISO, averageSnr);
+        blerSnr = binder_->phyPisaData.GetPscchBler(binder_->phyPisaData.AWGN, binder_->phyPisaData.SISO, averageSnr);
     }
     else
     {
         if (analytical_)
-            bler = binder_->phyPisaData.GetBlerAnalytical(mcs, averageSnr);
+            blerSnr = binder_->phyPisaData.GetBlerAnalytical(mcs, averageSnr);
         else
-            bler = binder_->phyPisaData.GetPsschBler(binder_->phyPisaData.AWGN, binder_->phyPisaData.SISO, mcs, averageSnr);
+            blerSnr = binder_->phyPisaData.GetPsschBler(binder_->phyPisaData.AWGN, binder_->phyPisaData.SISO, mcs, averageSnr);
+    }
+
+    if (averageSinr > binder_->phyPisaData.maxSnr())
+        blerSinr = 0;
+    else
+    if (lteInfo->getFrameType() == SCIPKT)
+    {
+        // TODO: Make this slightly tidier.
+        blerSinr = binder_->phyPisaData.GetPscchBler(binder_->phyPisaData.AWGN, binder_->phyPisaData.SISO, averageSinr);
+    }
+    else
+    {
+        if (analytical_)
+            blerSinr = binder_->phyPisaData.GetBlerAnalytical(mcs, averageSinr);
+        else
+            blerSinr = binder_->phyPisaData.GetPsschBler(binder_->phyPisaData.AWGN, binder_->phyPisaData.SISO, mcs, averageSinr);
     }
 
     double er = uniform(getEnvir()->getRNG(0),0.0, 1.0);
 
-    if (er <= bler)
+    bool resultSnr = true;
+    bool resultSinr = true;
+
+    if (er <= blerSnr)
     {
         // Signal too weak, we can't receive it
-        return false;
+        resultSnr = false;
     }
-    // Signal is strong enough, receive this Signal
 
-    return true;
+    if (er <= blerSnr) {
+        // Interference too strong, we can't decode this packet
+        resultSinr = false;
+    }
+
+    return std::make_tuple(resultSnr, resultSinr);
 }
 
 void LteRealisticChannelModel::computeLosProbability(double d,

--- a/src/stack/phy/ChannelModel/LteRealisticChannelModel.h
+++ b/src/stack/phy/ChannelModel/LteRealisticChannelModel.h
@@ -227,8 +227,9 @@ class LteRealisticChannelModel : public LteChannelModel
      * @param lteinfo pointer to the user control info
      * @param rsrpVector the received signal for each RB, if it has already been computed
      * @param mcs the modulation and coding scheme used in sending the message.
+     * @returns a tuple specifying whether it was successfully received based on SNR and SINR
      */
-    virtual bool error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs, bool interference);
+    virtual std::tuple<bool, bool> error_Mode4(LteAirFrame *frame, UserControlInfo* lteInfo, std::vector<double> rsrpVector, std::vector<double> sinrVector, int mcs);
     /*
      * Compute the error probability of the transmitted packet according to cqi used, txmode, and the received power
      * after that it throws a random number in order to check if this packet will be corrupted or not

--- a/src/stack/phy/layer/LtePhyVUeMode4.cc
+++ b/src/stack/phy/layer/LtePhyVUeMode4.cc
@@ -1372,10 +1372,9 @@ void LtePhyVUeMode4::decodeAirFrame(LteAirFrame* frame, UserControlInfo* lteInfo
                 lteInfo->setDeciderResult(false);
                 sciUnsensed_ += 1;
             } else {
-
-                prop_result = channelModel_->error_Mode4(frame, lteInfo, rsrpVector, sinrVector, 0, false);
-                if (prop_result)
-                    interference_result = channelModel_->error_Mode4(frame, lteInfo, rsrpVector, sinrVector, 0, true);
+                std::tuple<bool, bool> res = channelModel_->error_Mode4(frame, lteInfo, rsrpVector, sinrVector, 0);
+                prop_result = get<0>(res);
+                interference_result = get<1>(res);
 
                 SidelinkControlInformation *sci = check_and_cast<SidelinkControlInformation *>(pkt);
                 std::tuple<int, int> indexAndLength = decodeRivValue(sci, lteInfo);
@@ -1451,10 +1450,11 @@ void LtePhyVUeMode4::decodeAirFrame(LteAirFrame* frame, UserControlInfo* lteInfo
                         sciDecodedSuccessfully = true;
                     }
 
-                    if (lteInfo->getDirection() == D2D_MULTI)
-                        prop_result = channelModel_->error_Mode4(frame, lteInfo, rsrpVector, sinrVector, correspondingSCI->getMcs(), false);
-                        if (prop_result)
-                            interference_result = channelModel_->error_Mode4(frame, lteInfo, rsrpVector, sinrVector, correspondingSCI->getMcs(), true);
+                    if (lteInfo->getDirection() == D2D_MULTI) {
+                        std::tuple<bool, bool> res = channelModel_->error_Mode4(frame, lteInfo, rsrpVector, sinrVector, correspondingSCI->getMcs());
+                        prop_result = get<0>(res);
+                        interference_result = get<1>(res);
+                    }
 
                     // Remove the SCI
                     scis_.erase(it);


### PR DESCRIPTION
The previous implementation called error_mode4 twice to determine whether a packet drop was due to interference or propogation effects. This meant that two independent trials were performed on the packet drop as error_mode4 does remember state between calls. The two independent trials leads to overestimating the packet drop rates as the probability of a
transmission being correctly received with two trials is
           P_success = (1 - (P_tb_err)^2) (1 - (P_sci_err)^2)
rather than
                P_success = (1 - P_tb_err) (1 - P_sci_err)
in the one trial case. This was clearly seen in the offset between the expected BLER (given by the BLER data being used) and the simulated BLER. When compared the simulated BLER followed the two trial curves, rather than the raw BLER curve, provided by the dataset.
![BLER C-V2X (before fix)](https://user-images.githubusercontent.com/19177001/88711823-e06af300-d16c-11ea-9089-fb2b7d6b8e35.png)

This patch corrects this by changing error_mode4 function to perform both calculations using one random value. This means only one trial is performed but the desired granularity, being able to determine if a packet was dropped because of interference of propogation effects, is maintained. Instead of being called twice, error_mode4 returns a tuple of values indicating whether the packet was received correctly based on the interference and the propogation effects. Now, the BLER follows the expected value for the appropriate BLER data set.
![BLER C-V2X (after fix)](https://user-images.githubusercontent.com/19177001/88711827-e234b680-d16c-11ea-9128-2e5da44eb6a2.png)